### PR TITLE
add count parameter to limit output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ type root struct {
 	excludeLabelSelector []string
 	include              []string
 	exclude              []string
+	count                int
 	filename             string
 }
 
@@ -57,6 +58,7 @@ func newRootCommand(args []string) *cobra.Command {
 	rootCmd.Flags().StringArrayVarP(&root.include, "include", "i", []string{}, "Include resources matching criteria")
 	rootCmd.Flags().StringArrayVarP(&root.exclude, "exclude", "x", []string{}, "Exclude resources matching criteria")
 	rootCmd.Flags().StringVarP(&root.filename, "filename", "f", "", "Read manifests from file or URL")
+	rootCmd.Flags().IntVarP(&root.count, "count", "c", 0, "The amount of resources to include")
 
 	rootCmd.SetVersionTemplate(`{{.Version}}`)
 
@@ -126,6 +128,8 @@ func (r *root) run() error {
 			kfilt.AddExclude(s)
 		}
 	}
+
+	kfilt.SetCount(r.count)
 
 	filtered, err := kfilt.Filter(results)
 	if err != nil {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -6,10 +6,11 @@ import (
 	"github.com/ryane/kfilt/pkg/resource"
 )
 
-// Filter contains slices of inclusion and exclusion matchers
+// Filter contains slices of inclusion and exclusion matchers and other configuration
 type Filter struct {
 	Include []Matcher
 	Exclude []Matcher
+	count   int
 }
 
 // New creates a new Filter
@@ -17,6 +18,7 @@ func New() *Filter {
 	return &Filter{
 		Include: []Matcher{},
 		Exclude: []Matcher{},
+		count:   0,
 	}
 }
 
@@ -62,6 +64,12 @@ func (f *Filter) Filter(resources []resource.Resource) ([]resource.Resource, err
 		return ordermap[filtered[i].ID()] < ordermap[filtered[j].ID()]
 	})
 
+	// limit output
+	filtered, err = count(filtered, f.count)
+	if err != nil {
+		return filtered, err
+	}
+
 	return filtered, nil
 }
 
@@ -73,6 +81,10 @@ func (f *Filter) AddInclude(s Matcher) {
 // AddExclude adds an inclusion matcher
 func (f *Filter) AddExclude(s Matcher) {
 	f.Exclude = append(f.Exclude, s)
+}
+
+func (f *Filter) SetCount(count int) {
+	f.count = count
 }
 
 func filter(resources []resource.Resource, matcher Matcher) ([]resource.Resource, error) {
@@ -101,5 +113,16 @@ func exclude(resources []resource.Resource, matcher Matcher) ([]resource.Resourc
 			filtered = append(filtered, r)
 		}
 	}
+	return filtered, nil
+}
+
+func count(resources []resource.Resource, count int) ([]resource.Resource, error) {
+	filtered := []resource.Resource{}
+	if count > 0 && count <= len(resources) {
+		filtered = resources[:count]
+	} else {
+		filtered = resources
+	}
+
 	return filtered, nil
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -17,6 +17,7 @@ func TestFilter(t *testing.T) {
 		name    string
 		exclude excludeMatchers
 		include includeMatchers
+		count   int
 		expectIDs
 		expectedError func(err error) bool
 	}{
@@ -24,6 +25,64 @@ func TestFilter(t *testing.T) {
 			"no filters, return all",
 			excludeMatchers{},
 			includeMatchers{},
+			0,
+			expectIDs{
+				"/v1:serviceaccount::test-sa",
+				"/v1:serviceaccount::test-sa-2",
+				"/v1:pod:test-ns:test-pod",
+				"extensions/v1beta1:deployment:test-ns:test-deployment",
+				"extensions/v1beta1:deployment:app:app",
+				"/v1:configmap:app:app",
+			},
+			noError,
+		},
+		{
+			"no filters, return first 3",
+			excludeMatchers{},
+			includeMatchers{},
+			3,
+			expectIDs{
+				"/v1:serviceaccount::test-sa",
+				"/v1:serviceaccount::test-sa-2",
+				"/v1:pod:test-ns:test-pod",
+			},
+			noError,
+		},
+		{
+			"no filters, return all with count == length of input",
+			excludeMatchers{},
+			includeMatchers{},
+			6,
+			expectIDs{
+				"/v1:serviceaccount::test-sa",
+				"/v1:serviceaccount::test-sa-2",
+				"/v1:pod:test-ns:test-pod",
+				"extensions/v1beta1:deployment:test-ns:test-deployment",
+				"extensions/v1beta1:deployment:app:app",
+				"/v1:configmap:app:app",
+			},
+			noError,
+		},
+		{
+			"no filters, return all even with count larger than size of input",
+			excludeMatchers{},
+			includeMatchers{},
+			7,
+			expectIDs{
+				"/v1:serviceaccount::test-sa",
+				"/v1:serviceaccount::test-sa-2",
+				"/v1:pod:test-ns:test-pod",
+				"extensions/v1beta1:deployment:test-ns:test-deployment",
+				"extensions/v1beta1:deployment:app:app",
+				"/v1:configmap:app:app",
+			},
+			noError,
+		},
+		{
+			"no filters, handle negative count",
+			excludeMatchers{},
+			includeMatchers{},
+			-1,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -42,6 +101,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{
 				"/v1:pod:test-ns:test-pod",
 				"extensions/v1beta1:deployment:test-ns:test-deployment",
@@ -61,6 +121,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{
 				"extensions/v1beta1:deployment:test-ns:test-deployment",
 				"extensions/v1beta1:deployment:app:app",
@@ -77,6 +138,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -94,6 +156,7 @@ func TestFilter(t *testing.T) {
 					Kind: "ServiceAccount",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -111,6 +174,7 @@ func TestFilter(t *testing.T) {
 					Kind: "pod",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -133,6 +197,7 @@ func TestFilter(t *testing.T) {
 					Kind: "pod",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:pod:test-ns:test-pod",
@@ -150,6 +215,7 @@ func TestFilter(t *testing.T) {
 					Name: "test-sa-2",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -164,6 +230,7 @@ func TestFilter(t *testing.T) {
 					LabelSelector: "app",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -183,6 +250,7 @@ func TestFilter(t *testing.T) {
 					Kind: "ServiceAccount",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -198,6 +266,7 @@ func TestFilter(t *testing.T) {
 					LabelSelector: "app=test",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:pod:test-ns:test-pod",
@@ -213,6 +282,7 @@ func TestFilter(t *testing.T) {
 					LabelSelector: "app=test2",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa-2",
 			},
@@ -226,6 +296,7 @@ func TestFilter(t *testing.T) {
 					LabelSelector: "app!=test",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa-2",
 				"extensions/v1beta1:deployment:app:app",
@@ -241,6 +312,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa-2",
 				"extensions/v1beta1:deployment:app:app",
@@ -256,6 +328,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:pod:test-ns:test-pod",
@@ -271,6 +344,7 @@ func TestFilter(t *testing.T) {
 					LabelSelector: "app===test",
 				},
 			},
+			0,
 			expectIDs{
 				"/v1:serviceaccount::test-sa",
 				"/v1:serviceaccount::test-sa-2",
@@ -289,6 +363,7 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			includeMatchers{},
+			0,
 			expectIDs{},
 			filter.IsMatcherParseError,
 		},
@@ -303,7 +378,7 @@ func TestFilter(t *testing.T) {
 			for _, m := range test.exclude {
 				f.AddExclude(m)
 			}
-
+			f.SetCount(test.count)
 			results, err := f.Filter(input)
 			if !test.expectedError(err) {
 				t.Errorf("unexpected error for %s: %v", test.name, err)


### PR DESCRIPTION
adding flag: `  -c, --count int                The amount of resources to include`

Outputting only the first `count` resources, after applying all other filters. Output everything in the following cases:

- default value 0
- negative value
- `count` larger than length of filtered resources

Wanted to add this for convenience when using it interactively for testing purposes. Not a daily golang programmer, please be frank with comments.